### PR TITLE
Replace centos8 EOL base image in favor of stream8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream8
 
 RUN mkdir /disks && \
     yum -y update && \


### PR DESCRIPTION
- CentOS 8 EOL December 31st of 2021
- See https://www.centos.org/centos-linux-eol/